### PR TITLE
Update home page and résumé for Glean role

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ export default function Home() {
   return (
     <>
       <p>{"Hi, I'm Michael. My coworkers call me Vinny."}</p>
-      <p>Currently a Lead Solutions Engineer at <a href="https://firehydrant.io/">FireHydrant</a>. I work in technical sales, make music, write, and develop stuff.</p>
+      <p>Currently a Senior Solutions Engineer at <a href="https://www.glean.com/">Glean</a>. I work in technical sales, make music, write, and develop stuff.</p>
       <ul className="list-disc pl-8">
         <li><b>I dabble in indie music, which you can find</b> on my <a href="/music">music page</a>.</li>
         <li><b>All of my past projects</b> can be found <a href="/projects">here</a>.</li>

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -10,8 +10,19 @@ import {
 export default function Resume() {
   const jobs = [
     {
+      title: 'Glean',
+      date: 'Oct 2025 - Present',
+      positions: [
+        'Senior Solutions Engineer, Strategic (2025)',
+      ],
+      skills: 'Technical Sales, Cloud Infrastructure, JavaScript/TypeScript, LLMs, AI Agents',
+      description: 'Glean is an enterprise AI platform and work assistant that helps every team find answers, surface knowledge, and automate work. We turn company knowledge into instant, trusted intelligence so people spend less time prompting and searching and more time executing and delivering.',
+      location: 'Denver, CO',
+      href: 'https://www.glean.com/'
+    },
+    {
       title: 'FireHydrant',
-      date: 'Feb 2022 - Present',
+      date: 'Feb 2022 - Oct 2025',
       positions: [
         'Sr. Solutions Engineer (2022)',
         'Lead Solutions Engineer (2023)'


### PR DESCRIPTION
## Summary
- Update the home page intro to reflect the current role as Senior Solutions Engineer at Glean
- Add a Glean entry to the résumé (Oct 2025 – Present, remote from Denver)
- Update FireHydrant dates to Feb 2022 – Oct 2025

## Test plan
- [ ] Verify home page displays the updated Glean paragraph and link
- [ ] Verify résumé shows Glean as the most recent role with correct title, skills, and description
- [ ] Verify FireHydrant dates show Feb 2022 – Oct 2025